### PR TITLE
Workaround for issue #120 and a bug of tag filter

### DIFF
--- a/src/view/vm.js
+++ b/src/view/vm.js
@@ -148,7 +148,7 @@ afterLoad(function(){
                     return this.pxer.pfConfig.no_tag_any.join(' ');
                 },
                 set(value){
-                    this.pxer.pfConfig.no_tag_any =value.split(' ');
+                    this.pxer.pfConfig.no_tag_any = value ? value.split(' ') : [];
                 },
             },
             no_tag_every:{
@@ -156,7 +156,7 @@ afterLoad(function(){
                     return this.pxer.pfConfig.no_tag_every.join(' ');
                 },
                 set(value){
-                    this.pxer.pfConfig.no_tag_every =value.split(' ');
+                    this.pxer.pfConfig.no_tag_every = value ? value.split(' ') : [];
                 },
             },
             has_tag_some:{
@@ -164,7 +164,7 @@ afterLoad(function(){
                     return this.pxer.pfConfig.has_tag_some.join(' ');
                 },
                 set(value){
-                    this.pxer.pfConfig.has_tag_some =value.split(' ');
+                    this.pxer.pfConfig.has_tag_some = value ? value.split(' ') : [];
                 },
             },
             has_tag_every:{
@@ -172,7 +172,7 @@ afterLoad(function(){
                     return this.pxer.pfConfig.has_tag_every.join(' ');
                 },
                 set(value){
-                    this.pxer.pfConfig.has_tag_every =value.split(' ');
+                    this.pxer.pfConfig.has_tag_every = value ? value.split(' ') : [];
                 },
             },
             showFailTaskList(){

--- a/src/view/vm.js
+++ b/src/view/vm.js
@@ -61,7 +61,6 @@ afterLoad(function(){
             },
             showLoadBtn:true,
             errmsg:'',
-            analytics: {},
         }},
         created(){
             window['PXER_VM'] =this;


### PR DESCRIPTION
这个PR包含两个修复
### 针对Issue #120 的缓解方案
症状：见Issue #120
修复：将PxerApp和PxerAnalytics从Vue对象移出。将UI显示的变量放入pxer_app_delayed_syncer对象给Vue。worksNum、completedTaskCount、failCount与PxerApp定时轮询同步，其余需要的变量直接引用。
于Edge 42, Chrome 68, FF 61测试爬取50000个未再发现该问题。
### 针对Tag Filter的Bug修复
症状：在 作品中必须含有以下任意一个标签 或 作品中必须同时含有以下所有标签 中填写内容后清空会导致结果数量永远为0。
修复：因为"".split(' ')结果为[""]，所以检测value为""就直接赋值[]，不进行split