### PR TITLE
fix: encode search tag

### DIFF
--- a/src/app/PxerHtmlParser.js
+++ b/src/app/PxerHtmlParser.js
@@ -428,6 +428,6 @@ pxer.URLGetter = {
     search({ url = document.URL, page = 0 } = {}){
         const queryString = url.split('?')[1];
         const query = new URLSearchParams(queryString);
-        return `https://www.pixiv.net/ajax/search/artworks/${query.get('word')}?${queryString}&p=${page + 1}`;
+        return `https://www.pixiv.net/ajax/search/artworks/${encodeURIComponent(query.get('word'))}?${queryString}&p=${page + 1}`;
     },
 };


### PR DESCRIPTION
`pxer.URLGetter.search` 里对搜索页的 tag 进行了编码 `encodeURIComponent`。